### PR TITLE
fix corners of shadow on iOS

### DIFF
--- a/lib/BoxShadow.js
+++ b/lib/BoxShadow.js
@@ -45,7 +45,6 @@ export default class BoxShadow extends Component {
 				<Stop offset="1" stopColor={color} stopOpacity="0" key={key+'Linear1'} />
 			]
 		}
-		
 		const radial = (key) => {
 			return [
 				<Stop offset="0" stopColor={color} stopOpacity={opacity} key={key+'Radial0'} />,
@@ -65,10 +64,10 @@ export default class BoxShadow extends Component {
 						<LinearGradient id="bottom" x1="0" y1={rectHeight+lineWidth+2*radius} x2="0" y2={rectHeight+2*lineWidth+2*radius}>{linear('BoxBottom')}</LinearGradient>
 						<LinearGradient id="left" x1={lineWidth} y1="0" x2="0" y2="0">{linear('BoxLeft')}</LinearGradient>
 						<LinearGradient id="right" x1={rectWidth+lineWidth+2*radius} y1="0" x2={rectWidth+lineWidth*2+2*radius} y2={0}>{linear('BoxRight')}</LinearGradient>
-						<RadialGradient id="border-left-top" r={outerWidth} cx={outerWidth} cy={outerWidth}>{radial('BoxLeftTop')}</RadialGradient>
-						<RadialGradient id="border-left-bottom" r={outerWidth} cx={outerWidth} cy={lineWidth+radius+rectHeight}>{radial('BoxLeftBottom')}</RadialGradient>
-						<RadialGradient id="border-right-top" r={outerWidth} cx={lineWidth+radius+rectWidth} cy={outerWidth}>{radial('BoxRightTop')}</RadialGradient>
-						<RadialGradient id="border-right-bottom"  r={outerWidth} cx={lineWidth+radius+rectWidth} cy={lineWidth+radius+rectHeight}>{radial('BoxRightBottom')}</RadialGradient>
+						<RadialGradient id="border-left-top" r={outerWidth} cx={outerWidth} cy={outerWidth} fx={lineWidth+radius} fy={lineWidth+radius}>{radial('BoxLeftTop')}</RadialGradient>
+						<RadialGradient id="border-left-bottom" r={outerWidth} cx={outerWidth} cy={lineWidth+radius+rectHeight} fx={lineWidth+radius} fy={height+lineWidth-radius}>{radial('BoxLeftBottom')}</RadialGradient>
+						<RadialGradient id="border-right-top" r={outerWidth} cx={lineWidth+radius+rectWidth} cy={outerWidth} fx={width+lineWidth-radius} fy={lineWidth+radius}>{radial('BoxRightTop')}</RadialGradient>
+						<RadialGradient id="border-right-bottom"  r={outerWidth} cx={lineWidth+radius+rectWidth} cy={lineWidth+radius+rectHeight} fx={width+lineWidth-radius} fy={height+lineWidth-radius}>{radial('BoxRightBottom')}</RadialGradient>
 					</Defs>
 
 					<Path d={`M 0 ${outerWidth},Q 0 0 ${outerWidth} 0,v ${lineWidth},q ${-radius} 0 ${-radius} ${radius},h ${-lineWidth},z`} fill="url(#border-left-top)"/>

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   	"url": "https://github.com/879479119/react-native-shadow/issues"
   },
   "dependencies": {
-    "react-native-svg": "^4.3.1"
+    "react-native-svg": "5.1.4"
   }
 }


### PR DESCRIPTION
Hello,

i found an issue with iOS, which looks like this:
<img width="374" alt="glass_and_iphone_6_ _ios_10_3__14e269_" src="https://cloud.githubusercontent.com/assets/15254260/24751340/7eddb0b2-1ac9-11e7-8c7d-aa75c642ceca.png">
This pull request will fix that by changing focal point of gradient.