### PR TITLE
Added `animated` setting

### DIFF
--- a/lib/BorderShadow.js
+++ b/lib/BorderShadow.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react'
 import {View,Animated} from 'react-native'
-import Svg,{ Rect,Defs,LinearGradient,Stop,RadialGradient,Path } from 'react-native-svg'
+import Svg,{ Rect,Defs,LinearGradient,Stop } from 'react-native-svg'
 
 export default class BorderShadow extends Component {
 
@@ -17,29 +17,30 @@ export default class BorderShadow extends Component {
 
 		const lineWidth = border
 
-		switch (side){
+		switch (side) {
 			case "top":
 				return [
-					<Svg height={lineWidth} width={width+lineWidth} style={{position:"absolute",top:(inset?0:-lineWidth)}}>
-						<Defs>
-							<LinearGradient id="top" x1="0%" x2="0%" y1="100%" y2="0%">{linear('BorderTop')}</LinearGradient>
-							<LinearGradient id="top-inset" x1="0%" x2="0%" y1="0%" y2="100%">{linear('BorderTopInset')}</LinearGradient>
-						</Defs>
-						<Rect x={0} y={0} width={width} height={lineWidth} fill={`url(#top${inset?"-inset":""})`} />
-					</Svg>,
-					children
-				]
+						<Svg key={'Svg'} height={lineWidth} width={width+lineWidth} style={{position:"absolute",top:(inset?0:-lineWidth)}}>
+							<Defs>
+								<LinearGradient id="top" x1="0%" x2="0%" y1="100%" y2="0%">{linear('BorderTop')}</LinearGradient>
+								<LinearGradient id="top-inset" x1="0%" x2="0%" y1="0%" y2="100%">{linear('BorderTopInset')}</LinearGradient>
+							</Defs>
+							<Rect x={0} y={0} width={width} height={lineWidth} fill={`url(#top${inset?"-inset":""})`} />
+						</Svg>,
+						children,
+					]
+
 			case "bottom":
 				return [
 					children,
-					<Svg height={lineWidth} width={width+lineWidth} style={{position:"absolute",bottom:(inset?-lineWidth:0)}}>
+					<Svg key={'Svg'} height={lineWidth} width={width+lineWidth} style={{position:"absolute",bottom:(inset?-lineWidth:0)}}>
 						<Defs>
 							<LinearGradient id="bottom" x1="0%" x2="0%" y1="0%" y2="100%">{linear('BorderBottom')}</LinearGradient>
 							<LinearGradient id="bottom-inset" x1="0%" x2="0%" y1="100%" y2="0%">{linear('BorderBottomInset')}</LinearGradient>
 						</Defs>
 						<Rect x={0} y={0} width={width} height={lineWidth} fill={`url(#bottom${inset?"-inset":""})`} />
 					</Svg>
-				]
+					]
 			default:
 				throw new Error("Wrong Type of Side! We just support 'top' and 'bottom'")
 				return null

--- a/lib/BorderShadow.js
+++ b/lib/BorderShadow.js
@@ -1,11 +1,12 @@
 import React, {Component} from 'react'
-import {View} from 'react-native'
+import {View,Animated} from 'react-native'
 import Svg,{ Rect,Defs,LinearGradient,Stop,RadialGradient,Path } from 'react-native-svg'
 
 export default class BorderShadow extends Component {
-	render = () => {
 
-		const { setting:{side="bottom",width=0,color="#000",border=0,opacity=1,inset=false,style={}}, children } = this.props
+	content = () => {
+
+		const { setting:{side="bottom",width=0,color="#000",border=0,opacity=1,inset=false}, children } = this.props
 
 		const linear = (key) => {
 			return [
@@ -16,38 +17,49 @@ export default class BorderShadow extends Component {
 
 		const lineWidth = border
 
+		switch (side){
+			case "top":
+				return [
+					<Svg height={lineWidth} width={width+lineWidth} style={{position:"absolute",top:(inset?0:-lineWidth)}}>
+						<Defs>
+							<LinearGradient id="top" x1="0%" x2="0%" y1="100%" y2="0%">{linear('BorderTop')}</LinearGradient>
+							<LinearGradient id="top-inset" x1="0%" x2="0%" y1="0%" y2="100%">{linear('BorderTopInset')}</LinearGradient>
+						</Defs>
+						<Rect x={0} y={0} width={width} height={lineWidth} fill={`url(#top${inset?"-inset":""})`} />
+					</Svg>,
+					children
+				]
+			case "bottom":
+				return [
+					children,
+					<Svg height={lineWidth} width={width+lineWidth} style={{position:"absolute",bottom:(inset?-lineWidth:0)}}>
+						<Defs>
+							<LinearGradient id="bottom" x1="0%" x2="0%" y1="0%" y2="100%">{linear('BorderBottom')}</LinearGradient>
+							<LinearGradient id="bottom-inset" x1="0%" x2="0%" y1="100%" y2="0%">{linear('BorderBottomInset')}</LinearGradient>
+						</Defs>
+						<Rect x={0} y={0} width={width} height={lineWidth} fill={`url(#bottom${inset?"-inset":""})`} />
+					</Svg>
+				]
+			default:
+				throw new Error("Wrong Type of Side! We just support 'top' and 'bottom'")
+				return null
+		}
+	}
+
+	render = () => {
+
+		const { setting:{width, style, animated} } = this.props
+
 		return (
-			<View style={[{position:"relative",width:width},style]}>
-				{(()=>{
-					switch (side){
-						case "top":
-							return [
-								<Svg height={lineWidth} width={width+lineWidth} style={{position:"absolute",top:(inset?0:-lineWidth)}}>
-									<Defs>
-										<LinearGradient id="top" x1="0%" x2="0%" y1="100%" y2="0%">{linear('BorderTop')}</LinearGradient>
-										<LinearGradient id="top-inset" x1="0%" x2="0%" y1="0%" y2="100%">{linear('BorderTopInset')}</LinearGradient>
-									</Defs>
-									<Rect x={0} y={0} width={width} height={lineWidth} fill={`url(#top${inset?"-inset":""})`} />
-								</Svg>,
-								...children
-							]
-						case "bottom":
-							return [
-								...children,
-								<Svg height={lineWidth} width={width+lineWidth} style={{position:"absolute",bottom:(inset?-lineWidth:0)}}>
-									<Defs>
-										<LinearGradient id="bottom" x1="0%" x2="0%" y1="0%" y2="100%">{linear('BorderBottom')}</LinearGradient>
-										<LinearGradient id="bottom-inset" x1="0%" x2="0%" y1="100%" y2="0%">{linear('BorderBottomInset')}</LinearGradient>
-									</Defs>
-									<Rect x={0} y={0} width={width} height={lineWidth} fill={`url(#bottom${inset?"-inset":""})`} />
-								</Svg>
-							]
-						default:
-							throw new Error("Wrong Type of Side! We just support 'top' and 'bottom'")
-							return null
-					}
-				})()}
-			</View>
+			animated ? (
+				<Animated.View style={[{position:"relative",width:width},style]}>
+					{this.content()}
+				</Animated.View>
+			) : (
+				<View style={[{position:"relative",width:width},style]}>
+					{this.content()}
+				</View>
+			)
 		)
 	}
 }

--- a/lib/BoxShadow.js
+++ b/lib/BoxShadow.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react'
-import {View} from 'react-native'
+import {View,Animated} from 'react-native'
 import Svg,{ Rect,Defs,LinearGradient,Stop,RadialGradient,Path } from 'react-native-svg'
 
 
@@ -25,9 +25,10 @@ function colorRgb (color){
 }
 
 export default class BoxShadow extends Component {
-	render = () => {
+
+	content = () => {
 		//get the shadow settings and give them default values
-		const { setting:{width=0,height=0,color="#000",border=0,radius=0,opacity=1,x=0,y=0,style={}}, children } = this.props
+		const { disabled = false, setting:{width=0,height=0,color="#000",border=0,radius=0,opacity=1,x=0,y=0}, children } = this.props
 
 		//define the lengths
 		const lineWidth = border,
@@ -57,34 +58,51 @@ export default class BoxShadow extends Component {
 
 		//return a view ,whose background is a svg picture
 		return (
-			<View style={[{position:"relative",width:width,height:height},style]}>
-				<Svg height={height+lineWidth*2+radius*2} width={width+lineWidth*2+radius*2} style={{position:"absolute",top:y-lineWidth,left:x-lineWidth}}>
-					<Defs>
-						<LinearGradient id="top" x1="0%" x2="0%" y1="100%" y2="0%">{linear('BoxTop')}</LinearGradient>
-						<LinearGradient id="bottom" x1="0%" x2="0%" y1="0%" y2="100%">{linear('BoxBottom')}</LinearGradient>
-						<LinearGradient id="left" x1="100%" y1="0%" x2="0%" y2="0%">{linear('BoxLeft')}</LinearGradient>
-						<LinearGradient id="right" x1="0%" y1="0%" x2="100%" y2="0%" >{linear('BoxRight')}</LinearGradient>
-				
-						<RadialGradient id="border-left-top" r="100%" cx="100%" cy="100%" fx="100%" fy="100%">{radial('BoxLeftTop')}</RadialGradient>
-						<RadialGradient id="border-left-bottom" r="100%" cx="100%" cy="0%" fx="100%" fy="0%">{radial('BoxLeftBottom')}</RadialGradient>
-						<RadialGradient id="border-right-top" r="100%" cx="0%" cy="100%" fx="0%" fy="100%">{radial('BoxRightTop')}</RadialGradient>
-						<RadialGradient id="border-right-bottom" r="100%" cx="0%" cy="0%" fx="0%" fy="0%">{radial('BoxRightBottom')}</RadialGradient>
-					</Defs>
+				[disabled || (
+					<Svg height={height+lineWidth*2+radius*2} width={width+lineWidth*2+radius*2} style={{position:"absolute",top:y-lineWidth,left:x-lineWidth}}>
+						<Defs>
+							<LinearGradient id="top" x1="0%" x2="0%" y1="100%" y2="0%">{linear('BoxTop')}</LinearGradient>
+							<LinearGradient id="bottom" x1="0%" x2="0%" y1="0%" y2="100%">{linear('BoxBottom')}</LinearGradient>
+							<LinearGradient id="left" x1="100%" y1="0%" x2="0%" y2="0%">{linear('BoxLeft')}</LinearGradient>
+							<LinearGradient id="right" x1="0%" y1="0%" x2="100%" y2="0%" >{linear('BoxRight')}</LinearGradient>
 
-					<Path d={`M 0 ${outerWidth},Q 0 0 ${outerWidth} 0,v ${lineWidth},q ${-radius} 0 ${-radius} ${radius},h ${-lineWidth},z`} fill="url(#border-left-top)"/>
-					<Path d={`M ${rectWidth+lineWidth+radius} 0,q ${outerWidth} 0 ${outerWidth} ${outerWidth},h ${-lineWidth},q 0 ${-radius} ${-radius} ${-radius},v ${-lineWidth},z`} fill="url(#border-right-top)"/>
-					<Path d={`M ${rectWidth+lineWidth+2*radius} ${rectHeight+lineWidth+radius},h ${lineWidth},q 0 ${outerWidth} -${outerWidth} ${outerWidth},v ${-lineWidth},q ${radius} 0 ${radius} ${-radius},z`} fill="url(#border-right-bottom)"/>
-					<Path d={`M 0 ${rectHeight+lineWidth+radius},q 0 ${outerWidth} ${outerWidth} ${outerWidth},v ${-lineWidth},q ${-radius} 0 ${-radius} ${-radius},h ${-lineWidth},z`} fill="url(#border-left-bottom)"/>
+							<RadialGradient id="border-left-top" r="100%" cx="100%" cy="100%" fx="100%" fy="100%">{radial('BoxLeftTop')}</RadialGradient>
+							<RadialGradient id="border-left-bottom" r="100%" cx="100%" cy="0%" fx="100%" fy="0%">{radial('BoxLeftBottom')}</RadialGradient>
+							<RadialGradient id="border-right-top" r="100%" cx="0%" cy="100%" fx="0%" fy="100%">{radial('BoxRightTop')}</RadialGradient>
+							<RadialGradient id="border-right-bottom" r="100%" cx="0%" cy="0%" fx="0%" fy="0%">{radial('BoxRightBottom')}</RadialGradient>
+						</Defs>
 
-					<Rect x={outerWidth} y="0" width={rectWidth} height={lineWidth} fill="url(#top)" />
-					<Rect x="0" y={outerWidth} width={lineWidth} height={rectHeight} fill="url(#left)" />
-					<Rect x={rectWidth+lineWidth+2*radius} y={outerWidth} width={lineWidth} height={rectHeight} fill="url(#right)" />
-					<Rect x={outerWidth} y={rectHeight+lineWidth+2*radius} width={rectWidth} height={lineWidth} fill="url(#bottom)" />
+						<Path d={`M 0 ${outerWidth},Q 0 0 ${outerWidth} 0,v ${lineWidth},q ${-radius} 0 ${-radius} ${radius},h ${-lineWidth},z`} fill="url(#border-left-top)"/>
+						<Path d={`M ${rectWidth+lineWidth+radius} 0,q ${outerWidth} 0 ${outerWidth} ${outerWidth},h ${-lineWidth},q 0 ${-radius} ${-radius} ${-radius},v ${-lineWidth},z`} fill="url(#border-right-top)"/>
+						<Path d={`M ${rectWidth+lineWidth+2*radius} ${rectHeight+lineWidth+radius},h ${lineWidth},q 0 ${outerWidth} -${outerWidth} ${outerWidth},v ${-lineWidth},q ${radius} 0 ${radius} ${-radius},z`} fill="url(#border-right-bottom)"/>
+						<Path d={`M 0 ${rectHeight+lineWidth+radius},q 0 ${outerWidth} ${outerWidth} ${outerWidth},v ${-lineWidth},q ${-radius} 0 ${-radius} ${-radius},h ${-lineWidth},z`} fill="url(#border-left-bottom)"/>
 
-					<Path d={`M ${outerWidth} ${lineWidth},h ${rectWidth},q ${radius} 0 ${radius} ${radius},v ${rectHeight},q 0 ${radius} -${radius} ${radius},h -${rectWidth},q -${radius} 0 -${radius} -${radius},v -${rectHeight},q 0 -${radius} ${radius} -${radius}`} fill={`rgba(${rgb[0]},${rgb[1]},${rgb[2]},${opacity || 1})`}/>
-				</Svg>
-				{children}
-			</View>
+						<Rect x={outerWidth} y="0" width={rectWidth} height={lineWidth} fill="url(#top)" />
+						<Rect x="0" y={outerWidth} width={lineWidth} height={rectHeight} fill="url(#left)" />
+						<Rect x={rectWidth+lineWidth+2*radius} y={outerWidth} width={lineWidth} height={rectHeight} fill="url(#right)" />
+						<Rect x={outerWidth} y={rectHeight+lineWidth+2*radius} width={rectWidth} height={lineWidth} fill="url(#bottom)" />
+
+						<Path d={`M ${outerWidth} ${lineWidth},h ${rectWidth},q ${radius} 0 ${radius} ${radius},v ${rectHeight},q 0 ${radius} -${radius} ${radius},h -${rectWidth},q -${radius} 0 -${radius} -${radius},v -${rectHeight},q 0 -${radius} ${radius} -${radius}`} fill={`rgba(${rgb[0]},${rgb[1]},${rgb[2]},${opacity || 1})`}/>
+					</Svg>
+				),
+				children]
+		)
+	}
+
+	render = () => {
+
+		const { setting:{width=0,height=0,style={},animated} } = this.props
+
+		return (
+			animated ? (
+				<Animated.View style={[{position:"relative",width:width,height:height},style]}>
+					{content()}
+				</Animated.View>
+			) : (
+				<View style={[{position:"relative",width:width,height:height},style]}>
+					{content()}
+				</View>
+			)
 		)
 	}
 }


### PR DESCRIPTION
Added `animated` setting to allow change in wrapper component from View to Animated.View. Also fixed warning for each child in BorderShadow which got unpacked (should only allow one root for children)